### PR TITLE
Auto-reduce TX power when the ESP can't connect

### DIFF
--- a/main/uart_nic.c
+++ b/main/uart_nic.c
@@ -193,7 +193,8 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
             s_retry_num++;
             ESP_LOGI(TAG, "retry to connect to the AP");
         }
-        ESP_LOGI(TAG,"connect to the AP fail");
+        ESP_LOGI(TAG,"connect to the AP fail, now lowering RF power to reduce interference");
+	esp_wifi_set_max_tx_power(48); // 12dB (down from 20dB) to reduce antenna reflections, needed for some modules (see ESP8266_RTOS_SDK#1200)
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
         last_inbound_seen = now_seconds();
         associated = true;


### PR DESCRIPTION
Patch for https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/2303 until Espressif solves https://github.com/espressif/ESP8266_RTOS_SDK/issues/1200 :)

Kept it simple: First connection attempt is at normal power, subsequent ones at a reduced power. In the rare case the first connection was unsuccessful but we needed the full power, this still happens every time the Buddy board resets the ESP (each ~60 seconds until connection success).

Note the reduced TX power looks very low, but this is because the B/G/N standards already have different maximum levels. For example [802.11n is max 14dB](https://github.com/espressif/ESP8266_RTOS_SDK/issues/1200#issuecomment-1277429775), 13dB struggled so I kept 12dB.
Special thanks to @TD-er for his invaluable help!